### PR TITLE
Update bucket properties supported

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -123,6 +123,7 @@
         {sloppy_quorum, boolean()} |
         {timeout, pos_integer()} |
         {node_confirms, non_neg_integer()} |
+        {sync_on_write, all|backend|one} |
         asis.
 %% Valid request options for put requests. `return_body' returns the
 %% entire result of storing the object. `return_head' returns the

--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -74,7 +74,9 @@
         {search, boolean()} |
         {chash_keyfun, {atom(), atom()}} |
         {linkfun, {modfun, atom(), atom()}} |
-        {precommit|postcommit, [term()]}.
+        {precommit|postcommit, [term()]} |
+        {sync_on_write, all | backend | one} |
+        {aae_tree_exclude, boolean()}.
         %% Bucket property definitions (incomplete).
 -type bucket_props() :: [bucket_prop()]. %% Bucket properties
 -type quorum() :: non_neg_integer() | one | all | quorum | default.  %% A quorum setting for get/put/delete requests.

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 ]}.
 
 {deps, [
-    {riak_pb, {git, "https://github.com/OpenRiak/riak_pb", {branch, "nhse-o34-orkv.i42-aaetreeexclude"}}}
+    {riak_pb, {git, "https://github.com/OpenRiak/riak_pb", {branch, "openriak-3.4"}}}
 ]}.
 
 {edoc_opts, [

--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 ]}.
 
 {deps, [
-    {riak_pb, {git, "https://github.com/OpenRiak/riak_pb", {branch, "openriak-3.4"}}}
+    {riak_pb, {git, "https://github.com/OpenRiak/riak_pb", {branch, "nhse-o34-orkv.i42-aaetreeexclude"}}}
 ]}.
 
 {edoc_opts, [


### PR DESCRIPTION
Ass aae_tree_exclude bucket property, and also bring consistent support to options added since 2.2.5 - ensure all are supported (sync_on_write)