### PR TITLE
Update undefined data types

### DIFF
--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -45,11 +45,11 @@
 
 -export_type([datatype/0, update/1, context/0]).
 
--type maybe(T) :: T | undefined.
+-type maybe_t(T) :: T | undefined.
 -type datatype() :: term().
 -type typename() :: atom().
--type context() :: maybe(binary()).
--type update(T) :: maybe({typename(), T, context()}).
+-type context() :: maybe_t(binary()).
+-type update(T) :: maybe_t({typename(), T, context()}).
 
 %% Constructs a new, empty container for the type. Use this when
 %% creating a new key.
@@ -95,7 +95,7 @@ module_for_type(map)      -> riakc_map.
 
 %% @doc Returns the appropriate container module for the given term,
 %% if possible.
--spec module_for_term(datatype()) -> maybe(module()).
+-spec module_for_term(datatype()) -> maybe_t(module()).
 module_for_term(T) ->
     lists:foldl(fun(Mod, undefined) ->
                         case Mod:is_type(T) of


### PR DESCRIPTION
Fixes the following error: 
    ┌─ src/riakc_datatype.erl:
    │
 48 │  -type maybe(T) :: T | undefined.
    │                 ╰── syntax error before: '::'

    ┌─ src/riakc_datatype.erl:
    │
 51 │  -type context() :: maybe(binary()).
    │                     ╰── syntax error before: 'maybe'

    ┌─ src/riakc_datatype.erl:
    │
 52 │  -type update(T) :: maybe({typename(), T, context()}).
    │                     ╰── syntax error before: 'maybe'

    ┌─ src/riakc_datatype.erl:
    │
 98 │  -spec module_for_term(datatype()) -> maybe(module()).
    │                                       ╰── syntax error before: 'maybe'


    ┌─ src/riakc_datatype.erl:
    │
 46 │  -export_type([datatype/0, update/1, context/0]).
    │   ╰── type context() undefined

    ┌─ src/riakc_datatype.erl:
    │
 46 │  -export_type([datatype/0, update/1, context/0]).
    │   ╰── type update(_) undefined

    ┌─ src/riakc_datatype.erl:
    │
 60 │  -callback new(context()) -> datatype().
    │                ╰── type context() undefined

    ┌─ src/riakc_datatype.erl:
    │
 65 │  -callback new(Value::term(), context()) -> datatype().
    │                               ╰── type context() undefined

    ┌─ src/riakc_datatype.erl:
    │
 75 │  -callback to_op(datatype()) -> update(term()).
    │                                 ╰── type update(_) undefined
